### PR TITLE
Release 2.6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SiroSDK",
-            url: "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.0/SiroSDK.xcframework.zip",
-            checksum: "59b1b430fcaa0707469a5a4933674cb9d45ac72494e979e81ec67025afb47921"
+            url: "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.1/SiroSDK.xcframework.zip",
+            checksum: "fe787f58aed947ea257bc04fdfeee091c6dfd1fb33b9d282b499ce2b0b068525"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add SiroSDK to your project dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Siro-ai/SiroSDK.git", from: "2.5.1")
+    .package(url: "https://github.com/Siro-ai/SiroSDK.git", from: "2.6.1")
 ]
 ```
 

--- a/SiroSDK.podspec.json
+++ b/SiroSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SiroSDK",
-  "version": "2.5.1",
+  "version": "2.6.1",
   "summary": "Pod for integrating Siro.ai into an iOS project",
   "homepage": "https://siro.ai",
   "license": {
@@ -11,8 +11,8 @@
     "Siro.ai": "hello@siro.ai"
   },
   "source": {
-    "http": "https://github.com/Siro-ai/SiroSDK/releases/download/2.5.1/SiroSDK.xcframework.zip",
-    "sha256": "9f8f156f1515a7aaa71cdbb4628a0cf8f80913d281ceadb243e6de5d2c5b2b9f"
+    "http": "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.1/SiroSDK.xcframework.zip",
+    "sha256": "fe787f58aed947ea257bc04fdfeee091c6dfd1fb33b9d282b499ce2b0b068525"
   },
   "platforms": {
     "ios": "15.0"

--- a/SiroSDKDemo/SiroSDK.xcodeproj/project.pbxproj
+++ b/SiroSDKDemo/SiroSDK.xcodeproj/project.pbxproj
@@ -11,10 +11,10 @@
 		46ADBFF92A2724B400D7AF57 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ADBFF82A2724B400D7AF57 /* ContentView.swift */; };
 		46ADBFFB2A2724B500D7AF57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 46ADBFFA2A2724B500D7AF57 /* Assets.xcassets */; };
 		46ADBFFE2A2724B500D7AF57 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 46ADBFFD2A2724B500D7AF57 /* Preview Assets.xcassets */; };
-		C907DF212E2E890B0024000B /* SiroSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C907DF202E2E890B0024000B /* SiroSDK */; };
 		C907DF242E2E8D710024000B /* SiroSDKDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C907DF232E2E8D680024000B /* SiroSDKDelegate.swift */; };
 		C965DF062E99B243009E26B9 /* LogViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C965DF052E99B243009E26B9 /* LogViewerView.swift */; };
 		C96BE9842D80AAFE00B089E0 /* AudioVisualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96BE9832D80AAF600B089E0 /* AudioVisualizerView.swift */; };
+		C9836BA22FB504C8003E90C7 /* SiroSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C9836BA12FB504C8003E90C7 /* SiroSDK */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C907DF212E2E890B0024000B /* SiroSDK in Frameworks */,
+				C9836BA22FB504C8003E90C7 /* SiroSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -113,7 +113,7 @@
 			);
 			name = SiroSDKExampleSwiftUI;
 			packageProductDependencies = (
-				C907DF202E2E890B0024000B /* SiroSDK */,
+				C9836BA12FB504C8003E90C7 /* SiroSDK */,
 			);
 			productName = SiroKitExample;
 			productReference = 46ADBFF42A2724B400D7AF57 /* SiroSDKExampleSwiftUI.app */;
@@ -144,7 +144,7 @@
 			);
 			mainGroup = 46ADBFCC2A27245F00D7AF57;
 			packageReferences = (
-				C907DF222E2E8C370024000B /* XCRemoteSwiftPackageReference "SiroSDK" */,
+				C9836BA02FB504C8003E90C7 /* XCRemoteSwiftPackageReference "SiroSDK" */,
 			);
 			productRefGroup = 46ADBFD72A27245F00D7AF57 /* Products */;
 			projectDirPath = "";
@@ -458,20 +458,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C907DF222E2E8C370024000B /* XCRemoteSwiftPackageReference "SiroSDK" */ = {
+		C9836BA02FB504C8003E90C7 /* XCRemoteSwiftPackageReference "SiroSDK" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Siro-ai/SiroSDK";
 			requirement = {
-				kind = exactVersion;
-				version = 2.6.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C907DF202E2E890B0024000B /* SiroSDK */ = {
+		C9836BA12FB504C8003E90C7 /* SiroSDK */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C907DF222E2E8C370024000B /* XCRemoteSwiftPackageReference "SiroSDK" */;
+			package = C9836BA02FB504C8003E90C7 /* XCRemoteSwiftPackageReference "SiroSDK" */;
 			productName = SiroSDK;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SiroSDKDemo/SiroSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SiroSDKDemo/SiroSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Siro-ai/SiroSDK",
       "state" : {
-        "revision" : "59b1b430fcaa0707469a5a4933674cb9d45ac72494e979e81ec67025afb47921",
-        "version" : "2.6.0"
+        "revision" : "93fa93c60dca142dfa4ed5dc1b8e0fd6f54e7f67",
+        "version" : "2.6.1"
       }
     }
   ],

--- a/SiroSDKDemo/SiroSDKExampleSwiftUI/ContentView.swift
+++ b/SiroSDKDemo/SiroSDKExampleSwiftUI/ContentView.swift
@@ -77,13 +77,13 @@ struct ContentView: View {
     @State private var isLoadingRecordings = false
     @State private var recordingTitle: String = ""
     @State private var isPrivate: Bool = false
-    @State private var isAutomaticSplitEnabled: Bool = false
     @State private var isRecording: Bool = false
     @State private var crmObjectId: String = ""
     @State private var crmObjectType: String = ""
     @State private var crmTenantId: String = ""
     @State private var crmPlatform: String = ""
     @State private var uploadModeIndex: Int = 0
+    @State private var maxDurationSeconds: String = "30"
     
     // Token handler event tracking
     @State private var tokenEvents: [TokenEvent] = []
@@ -138,6 +138,43 @@ struct ContentView: View {
                         default: SiroSDK.uploadMode = .always
                         }
                     }
+
+                    // Test Harnesses (new in 2.6.1)
+                    // - Max duration: shorten the auto-stop threshold to test
+                    //   didReachMaxRecordingDuration without recording for 8h.
+                    // - Simulate Encode Error: fires the same code path as a
+                    //   real AVAudioRecorder encode error so consumers can
+                    //   verify their didEncounterRecordingError handling
+                    //   without exhausting device storage.
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Test Harnesses")
+                            .font(.subheadline)
+                        HStack {
+                            Text("Max duration (s):")
+                                .font(.caption)
+                            TextField("seconds", text: $maxDurationSeconds)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.numberPad)
+                                .frame(maxWidth: 100)
+                            Button("Apply") {
+                                if let s = TimeInterval(maxDurationSeconds), s > 0 {
+                                    SiroSDK.maxRecordingDuration = s
+                                    fetchResult = "✅ Max duration set to \(Int(s))s"
+                                } else {
+                                    fetchResult = "❌ Invalid duration"
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                        Button(action: {
+                            SiroSDK.simulateRecordingEncodeError()
+                            fetchResult = "✅ Simulated encode error fired"
+                        }) {
+                            Text("Simulate Encode Error")
+                        }
+                        .buttonStyle(ActionButtonStyle())
+                    }
+                    .padding(.vertical, 4)
 
                     // Offline Initialization
                     VStack(alignment: .leading, spacing: 8) {
@@ -292,8 +329,6 @@ struct ContentView: View {
                                     .textFieldStyle(RoundedBorderTextFieldStyle())
                                 
                                 Toggle("Private Recording", isOn: $isPrivate)
-                                
-                                Toggle("Automatic Split", isOn: $isAutomaticSplitEnabled)
 
                                 Text("CRM Settings")
                                     .font(.subheadline)
@@ -314,7 +349,6 @@ struct ContentView: View {
                                 Button(action: {
                                     SiroSDK.recordingTitle = recordingTitle
                                     SiroSDK.isPrivateRecording = isPrivate
-                                    SiroSDK.automaticSplitEnabled = isAutomaticSplitEnabled
                                     SiroSDK.crmObjectId = crmObjectId.isEmpty ? nil : crmObjectId
                                     SiroSDK.crmObjectType = crmObjectType.isEmpty ? nil : crmObjectType
                                     SiroSDK.crmTenantId = crmTenantId.isEmpty ? nil : crmTenantId

--- a/SiroSDKDemo/SiroSDKExampleSwiftUI/ContentView.swift
+++ b/SiroSDKDemo/SiroSDKExampleSwiftUI/ContentView.swift
@@ -552,9 +552,6 @@ struct RecordingView:View{
                     Text("Private: \(recording.isPrivate ? "Yes" : "No")")
                         .font(.caption)
                         .foregroundColor(.gray)
-                    Text("Auto Split: \(recording.isAutomaticSplitEnabled ? "Enabled" : "Disabled")")
-                        .font(.caption)
-                        .foregroundColor(.gray)
                     
                     if let crmObjectId = recording.crmObjectId {
                         Text("CRM Object ID: \(crmObjectId)")

--- a/SiroSDKDemo/SiroSDKExampleSwiftUI/SiroSDKDelegate.swift
+++ b/SiroSDKDemo/SiroSDKExampleSwiftUI/SiroSDKDelegate.swift
@@ -98,6 +98,19 @@ struct RecordingDelegate: SiroSDKRecordingDelegate {
         print("didSaveRecording called")
     }
 
+    /// Fires when the SDK detects a recording-time error that affects audio
+    /// capture reliability — most commonly an AVFoundation encode/write
+    /// failure caused by insufficient device storage. The in-progress
+    /// recording's most recent chunks may be empty or truncated; consumers
+    /// should typically stop the recording and surface a user-facing
+    /// message ("check available storage", etc.).
+    func didEncounterRecordingError(localRecordingId: String?, error: SiroSDKRecordingError) {
+        switch error {
+        case .encodeError(let underlying):
+            print("didEncounterRecordingError: encodeError on \(localRecordingId ?? "-") — \(underlying?.localizedDescription ?? "no underlying error")")
+        }
+    }
+
     func didUpdateD2DMode(enabled _: Bool) {
         print("didUpdateD2DMode called")
     }


### PR DESCRIPTION
Brings `main` in line with the already-published **2.6.1** release.

The `2.6.1` git tag and the GitHub release (with `SiroSDK.xcframework.zip` attached) already exist; `main` was never updated to point at them. This branch fixes that.

### Changes
- `Package.swift` — binary target URL + checksum → `2.6.1`
- `SiroSDK.podspec.json` — version + source URL + sha256 → `2.6.1` (was stale at `2.5.1`)
- `README.md` — version reference
- `SiroSDKDemo/` — wire demo app SPM dependency to `2.6.1`, example updates

No code/binary changes — the `2.6.1` xcframework is already live.