### PR TITLE
Release 2.6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SiroSDK",
-            url: "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.1/SiroSDK.xcframework.zip",
-            checksum: "fe787f58aed947ea257bc04fdfeee091c6dfd1fb33b9d282b499ce2b0b068525"
+            url: "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.2/SiroSDK.xcframework.zip",
+            checksum: "5ad5a7b861a69264595efae4b8fa42f010aa454b76e2ae1f71e5f16b2d578079"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add SiroSDK to your project dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Siro-ai/SiroSDK.git", from: "2.6.1")
+    .package(url: "https://github.com/Siro-ai/SiroSDK.git", from: "2.6.2")
 ]
 ```
 

--- a/SiroSDK.podspec.json
+++ b/SiroSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SiroSDK",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "summary": "Pod for integrating Siro.ai into an iOS project",
   "homepage": "https://siro.ai",
   "license": {
@@ -11,8 +11,8 @@
     "Siro.ai": "hello@siro.ai"
   },
   "source": {
-    "http": "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.1/SiroSDK.xcframework.zip",
-    "sha256": "fe787f58aed947ea257bc04fdfeee091c6dfd1fb33b9d282b499ce2b0b068525"
+    "http": "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.2/SiroSDK.xcframework.zip",
+    "sha256": "5ad5a7b861a69264595efae4b8fa42f010aa454b76e2ae1f71e5f16b2d578079"
   },
   "platforms": {
     "ios": "15.0"


### PR DESCRIPTION
Bumps the public SiroSDK distribution to **2.6.2**.

| File | Change |
|---|---|
| `Package.swift` | binary target URL + checksum → `2.6.2` (`5ad5a7b8…`) |
| `SiroSDK.podspec.json` | version + source URL + sha256 → `2.6.2` |
| `README.md` | SPM example → `from: "2.6.2"` |

The `2.6.2` xcframework was built from SiroKit `develop` (`eb7bde8`) via the documented `build-xcframework.sh` flow.

⚠️ **Do not merge until the `2.6.2` GitHub release is published with the binary attached** — otherwise `main` would reference a download URL that 404s. Once the release is live, squash-merge (like #36).