### PR TITLE
Release 2.6.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SiroSDK",
-            url: "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.2/SiroSDK.xcframework.zip",
-            checksum: "5ad5a7b861a69264595efae4b8fa42f010aa454b76e2ae1f71e5f16b2d578079"
+            url: "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.3/SiroSDK.xcframework.zip",
+            checksum: "f87e39b6ed6dfabce1045a9c4f912f985cecae0dba51aeb07d94b419fc7b1035"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add SiroSDK to your project dependencies:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Siro-ai/SiroSDK.git", from: "2.6.2")
+    .package(url: "https://github.com/Siro-ai/SiroSDK.git", from: "2.6.3")
 ]
 ```
 

--- a/SiroSDK.podspec.json
+++ b/SiroSDK.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SiroSDK",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "summary": "Pod for integrating Siro.ai into an iOS project",
   "homepage": "https://siro.ai",
   "license": {
@@ -11,8 +11,8 @@
     "Siro.ai": "hello@siro.ai"
   },
   "source": {
-    "http": "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.2/SiroSDK.xcframework.zip",
-    "sha256": "5ad5a7b861a69264595efae4b8fa42f010aa454b76e2ae1f71e5f16b2d578079"
+    "http": "https://github.com/Siro-ai/SiroSDK/releases/download/2.6.3/SiroSDK.xcframework.zip",
+    "sha256": "f87e39b6ed6dfabce1045a9c4f912f985cecae0dba51aeb07d94b419fc7b1035"
   },
   "platforms": {
     "ios": "15.0"


### PR DESCRIPTION
Bumps the public SiroSDK distribution to **2.6.3** (ships SiroKit #105).

| File | Change |
|---|---|
| `Package.swift` | binary target URL + checksum → `2.6.3` (`f87e39b6…`) |
| `SiroSDK.podspec.json` | version + source URL + sha256 → `2.6.3` |
| `README.md` | SPM example → `from: "2.6.3"` |

Built from SiroKit `develop` (`265016a`) on Xcode 26.4.

⚠️ **Do not merge until the `2.6.3` GitHub release is published** (the draft already has the binary attached) — otherwise `main` points at a download URL that 404s. Then squash-merge, like #37.